### PR TITLE
Create a directory if needed

### DIFF
--- a/src/doppkit/cache.py
+++ b/src/doppkit/cache.py
@@ -146,8 +146,11 @@ async def cache_url(args, url, headers, client, progress):
                     )
             c.target.flush()
             c.target.seek(0)
+        else:  # isinstance(c.target, pathlib.Path)
+            # create parent directory/directories if needed
+            if c.target.parent is not None:
+                c.target.parent.mkdir(parents=True, exis4t_ok=True)
 
-        else:
             # we are writing to disk asyncronously
             async with aiofiles.open(c.target, "wb+") as f:
                 async for chunk in response.aiter_bytes():


### PR DESCRIPTION
The Content-Disposition header can reference a filename not just of the form filename.txt, but of the form directory/filename.txt.  This commit allows for accepting content of that type.

Fixes #25 