### PR TITLE
Allow for redirect related status codes

### DIFF
--- a/src/doppkit/__init__.py
+++ b/src/doppkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 from . import cache
 from . import grid

--- a/src/doppkit/cache.py
+++ b/src/doppkit/cache.py
@@ -130,7 +130,8 @@ async def cache_url(
         request = client.build_request("GET", url, headers=headers, timeout=None)
         response = await client.send(request, stream=True)
         
-        if response.status_code != httpx.codes.OK:
+        if response.is_error:
+            logger.error(f"GRiD returned an error code {response.status_code} with message: {response.text}")
             return response
 
         filename = None  # placeholder

--- a/src/doppkit/cli/__main__.py
+++ b/src/doppkit/cli/__main__.py
@@ -40,7 +40,6 @@ def cli(ctx, token, url, log_level, threads, progress, disable_ssl_verification)
     logging.basicConfig(level=numeric_level)
 
     # Log program args
-    logging.debug(f"Log level: {log_level}")
 
     app = Application(
         token=token,


### PR DESCRIPTION
doppkit was explicitly checking for an OK status code, but instead it should check for an error.