### PR TITLE
Preserve more dir structure of exportfiles

### DIFF
--- a/src/doppkit/__init__.py
+++ b/src/doppkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.0rc3"
+__version__ = "0.3.0rc4"
 
 from . import cache
 from . import grid

--- a/src/doppkit/cache.py
+++ b/src/doppkit/cache.py
@@ -149,8 +149,8 @@ async def cache_url(
             await response.aclose()
             response = await client.send(request, stream=True)
             total = max(total, int(response.headers.get("Content-length", 0)))
-        if filename is not None:
-            filename = pathlib.Path(url.storage_path.lstrip("/") / filename)
+        if filename is not None:  # we are not saving to BytesIO
+            filename = pathlib.Path(url.storage_path.lstrip("/"))
         c = Content(
             response.headers,
             filename=filename,

--- a/src/doppkit/grid.py
+++ b/src/doppkit/grid.py
@@ -292,10 +292,16 @@ class Grid:
         auxfile_urls = set()
         for e in exports:
             ex = e['exports']
-
             for item in ex:
                 # need to construct "storage_path" attribute in exportfiles
-                files.extend(iter(item['exportfiles']))
+                # currently have to reconstruct from "storage_name"
+                # format is /u02/exports/<userid>/<aoiid>/<exportid>/bits/we/care/about.tif
+                export_id = item["id"]
+                for exportfile in iter(item['exportfiles']):
+                    # we're dealing with older API before to storage_path attribute
+                    if "storage_path" not in exportfile.keys():
+                        exportfile["storage_path"] =  f"./{exportfile['datatype']}{exportfile['storage_name'].rpartition(str(export_id))[-1]}"
+                    files.append(exportfile)
                 for auxfile in item["auxfiles"]:
                     if auxfile["url"] not in auxfile_urls:
                         files.append(auxfile)


### PR DESCRIPTION
This PR adds logic to attempt to reconstruct `storage_path` attribute in exportfiles if not present.  The reconstructed path won't match the webui download variant precisely, but should avoid the nasty clobber issues we're concerned about.