### PR TITLE
Correct Usage of 'storage_path' - 0.3.1 Release

### DIFF
--- a/src/doppkit/__init__.py
+++ b/src/doppkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from . import cache
 from . import grid

--- a/src/doppkit/cli/sync.py
+++ b/src/doppkit/cli/sync.py
@@ -60,7 +60,7 @@ async def sync(args: 'Application', id_: str) -> Iterable[Content]:
             urls.append(
                 DownloadUrl(
                     download_url,
-                    exportfile.get("storage_path", "."),
+                    f"{exportfile.get('storage_path', '.')}/{exportfile['name']}",
                     exportfile["filesize"]
                 )
             )

--- a/src/doppkit/grid.py
+++ b/src/doppkit/grid.py
@@ -232,7 +232,6 @@ class Grid:
             raise RuntimeError(f"GRiD Task Endpoint Returned Error {r.status_code}")
         return output
 
-
     async def get_exports(self, export_id: int) -> list[Union[Exportfile, Auxfile]]:
         """
         Parameters
@@ -300,7 +299,10 @@ class Grid:
                 for exportfile in iter(item['exportfiles']):
                     # we're dealing with older API before to storage_path attribute
                     if "storage_path" not in exportfile.keys():
-                        exportfile["storage_path"] =  f"./{exportfile['datatype']}{exportfile['storage_name'].rpartition(str(export_id))[-1]}"
+                        exportfile["storage_path"] = (
+                            f"./{exportfile['datatype']}"
+                            f"{exportfile['storage_name'].rpartition(str(export_id))[-1].rpartition('/')[0]}"
+                        )
                     files.append(exportfile)
                 for auxfile in item["auxfiles"]:
                     if auxfile["url"] not in auxfile_urls:

--- a/src/doppkit/gui/window.py
+++ b/src/doppkit/gui/window.py
@@ -441,7 +441,7 @@ class Window(QtWidgets.QMainWindow):
                         urls.append(
                             DownloadUrl(
                                 export_file["url"],
-                                export_file.get("storage_path", "."),
+                                f"{export_file.get('storage_path', '.')}/{export_file['name']}",
                                 export_file["filesize"]
                             )
                         )


### PR DESCRIPTION
the storage_path attribute does not contain the name of the file, when rebuilding the storage_path attribute from the storage_name, I need to exclude the filename, and when constructing the DownloadUrl object, I need to append the filename to what is stored in storage_path to be saved in the correct location