### PR TITLE
Grab Licensefiles

### DIFF
--- a/src/doppkit/__init__.py
+++ b/src/doppkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 from . import cache
 from . import grid


### PR DESCRIPTION
PR also removes some unneeded log entries, handles the case where the total download size is 0 causing a zero division error.