### PR TITLE
Address couple of issues with the same asset being in multiple exports

### DIFF
--- a/src/doppkit/__init__.py
+++ b/src/doppkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 from . import cache
 from . import grid

--- a/src/doppkit/gui/window.py
+++ b/src/doppkit/gui/window.py
@@ -44,7 +44,7 @@ class QtProgress(QtCore.QObject):
         # key is AOI PK
         self.aois: dict[int, list[ProgressTracking]] = defaultdict(list)
 
-        self.urls_to_export_id: dict[str, int] = {}
+        self.urls_to_export_id: dict[str, list[int]] = defaultdict(list)
 
         self.export_files: dict[int, dict[str, ExportFileProgress]] = defaultdict(dict)
 
@@ -66,40 +66,40 @@ class QtProgress(QtCore.QObject):
             None
         """
 
-        export_id = self.urls_to_export_id[url]
-        self.export_files[export_id][url] = ExportFileProgress(
-            url,
-            export_id=export_id,
-            total=total
-        )
+        export_ids = self.urls_to_export_id[url]
+        for export_id in export_ids:
+            self.export_files[export_id][url] = ExportFileProgress(
+                url,
+                export_id=export_id,
+                total=total
+            )
 
     def update(self, name: str, url: str, completed: int) -> None:
-        export_id = self.urls_to_export_id[url]
-
-        old_progress = self.export_files[export_id][url]
-        self.export_files[export_id][url] = ExportFileProgress(
-            url,
-            export_id=export_id,
-            current=completed,
-            total=old_progress.total,
-            is_complete=completed >= old_progress.total
-        )
-
-        export_progress = self.export_progress[export_id]
-        export_downloaded = sum(file_progress.current for file_progress in self.export_files[export_id].values())
-        export_progress.update(export_downloaded)
-        self.taskUpdated.emit(export_progress)
+        export_ids = self.urls_to_export_id[url]
+        for export_id in export_ids:
+            old_progress = self.export_files[export_id][url]
+            self.export_files[export_id][url] = ExportFileProgress(
+                url,
+                export_id=export_id,
+                current=completed,
+                total=old_progress.total,
+                is_complete=completed >= old_progress.total
+            )
+            export_progress = self.export_progress[export_id]
+            export_downloaded = sum(file_progress.current for file_progress in self.export_files[export_id].values())
+            export_progress.update(export_downloaded)
+            self.taskUpdated.emit(export_progress)
 
     def complete_task(self, name: str, url: str) -> None:
-        export_id = self.urls_to_export_id[url]
-        old_progress = self.export_files[export_id][url]
+        export_ids = self.urls_to_export_id[url]
 
-        self.update(name, url, old_progress.total)
-
-        export_progress = self.export_progress[export_id]
-        if all(export_file.is_complete for export_file in self.export_files[export_id].values()):
-            export_progress.is_complete = True
-            self.taskCompleted.emit(export_progress)
+        for export_id in export_ids:
+            old_progress = self.export_files[export_id][url]
+            self.update(name, url, old_progress.total)
+            export_progress = self.export_progress[export_id]
+            if all(export_file.is_complete for export_file in self.export_files[export_id].values()):
+                export_progress.is_complete = True
+                self.taskCompleted.emit(export_progress)
 
     def update_export_progress(self):
         pass
@@ -437,7 +437,7 @@ class Window(QtWidgets.QMainWindow):
                         )
                         print(f"{download_file.save_path} = {download_file.total} bytes")
                         download_size += download_file.total
-                        self.progressInterconnect.urls_to_export_id[download_file.url] = export["id"]
+                        self.progressInterconnect.urls_to_export_id[download_file.url].append(export["id"])
                 progress_tracker = ProgressTracking(
                     export["id"],
                     export_name=export["name"],


### PR DESCRIPTION
This PR addresses a number of issues when the same file is in multiple exports.  This is common in the case where an AOI has multiple exports which may have an accompanying licensefile.


Also took the opportunity to address the re-enabling of buttons in the event of an exception is raised.

Fixes #48 