### PR TITLE
When uploading directory, preserve structure

### DIFF
--- a/src/doppkit/__init__.py
+++ b/src/doppkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.0rc0"
+__version__ = "0.4.0rc1"
 
 from . import cache
 from . import grid

--- a/src/doppkit/grid.py
+++ b/src/doppkit/grid.py
@@ -178,6 +178,7 @@ class Grid:
     async def upload_asset(
             self,
             filepath: pathlib.Path,
+            directory: Optional[pathlib.Path] = None,
             bytes_per_chunk=MULTIPART_BYTES_PER_CHUNK,
             progress: Optional[Progress]=None
     ):
@@ -185,7 +186,11 @@ class Grid:
         source_size = filepath.stat().st_size
         chunks_count = int(math.ceil(source_size / float(bytes_per_chunk)))
 
-        key = f"test-ogi/upload/{filepath.name}"
+        key = ""
+        if directory is not None:
+            key += f"{directory.as_posix().strip('/')}/"
+
+        key += f"{filepath.name}"
         upload_endpoint_url = f"{self.args.url}{upload_endpoint_ext}"
 
         headers = {"Authorization": f"Bearer {self.args.token}"}

--- a/src/doppkit/gui/MenuBar.py
+++ b/src/doppkit/gui/MenuBar.py
@@ -90,7 +90,8 @@ class FileMenu(QMenu):
             options=QFileDialog.Option.ReadOnly
         )
 
-        if directory is None:
+
+        if directory == "":
             # user cancelled, abort
             return None
 
@@ -111,7 +112,7 @@ class FileMenu(QMenu):
             raise RuntimeError("Main Window not found, how did this happen?")
 
         if hasattr(widget, 'uploadFiles'):
-            widget.uploadFiles(files_to_upload)
+            widget.uploadFiles(files_to_upload, directory=directory)
     
     @Slot()
     def _resetSettingsDialog(self) -> None:

--- a/src/doppkit/gui/window.py
+++ b/src/doppkit/gui/window.py
@@ -3,7 +3,7 @@ from .. import __version__
 from ..grid import Grid, AOI
 from .cache import cache, DownloadUrl
 from qtpy import QtCore, QtGui, QtWidgets
-from typing import Optional, NamedTuple
+from typing import Optional, NamedTuple, Union
 from collections import defaultdict
 from dataclasses import dataclass
 import pathlib
@@ -413,7 +413,11 @@ class Window(QtWidgets.QMainWindow):
         setting.setValue("grid/token", self.doppkit.token)
 
     @qasync.asyncSlot()
-    async def uploadFiles(self, files: list[str]):
+    async def uploadFiles(
+        self,
+        files: list[str],
+        directory: Optional[Union[str, pathlib.Path]]=None
+    ):
 
         items = [
             UploadItem(filepath, self.uploadProgressInterconnect)
@@ -438,8 +442,15 @@ class Window(QtWidgets.QMainWindow):
         self.uploadView.show()
 
         for file_ in files:
+            file_path = pathlib.Path(file_)
+            relative_directory: Optional[pathlib.Path]
+            if directory is not None:
+                relative_directory = file_path.relative_to(pathlib.Path(directory).parent).parent
+            else:
+                relative_directory = None
             await api.upload_asset(
-                pathlib.Path(file_),
+                file_path,
+                directory=relative_directory,
                 progress=self.uploadProgressInterconnect
             )
 


### PR DESCRIPTION
In the case where directories are uploaded, the relative directory structure is preserved and used as the `key` argument when creating the upload_id.

Also fixes bug where an upload was attempted even if the upload directory dialog was cancelled out of.