### PR TITLE
Pin PySide6-Essentials to ~=6.6.0 (6.6.3.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ homepage = "https://github.com/hobuinc/doppkit"
 repository = "https://github.com/hobuinc/doppkit"
 
 [project.optional-dependencies]
-GUI = ["qtpy", "PySide6-essentials", "qasync"]
+GUI = ["qtpy", "PySide6-essentials~=6.6.0", "qasync"]
 
 [tool.black]
 line-length = 88

--- a/src/doppkit/__init__.py
+++ b/src/doppkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.1dev0"
+__version__ = "0.4.1"
 
 from . import cache
 from . import grid


### PR DESCRIPTION
Looks like there may be an issue with PySide6 6.7.0, keeping things to 6.6