### PR TITLE
Log traceback when cache returns an exception

### DIFF
--- a/src/doppkit/grid.py
+++ b/src/doppkit/grid.py
@@ -356,7 +356,12 @@ class Grid:
             return []
         except AttributeError as e:
             if isinstance(export_files[0], Exception):
-                logger.error(f"Doppkit Cache Function Returned the following exception: {export_files[0]}")
+                logger.error("Doppkit Cache Function Returned the following exception:")
+                logger.error(export_files[0], exc_info=export_files[0])
+                logger.info(
+                    "If the above is a httpx.ReadError, likely a timeout on the GRiD "
+                    "end has interrupted the download."
+                )
                 raise export_files[0] from e
             elif isinstance(export_files[0], httpx.Response):            
                 await export_files[0].aread()


### PR DESCRIPTION
The cache (download) operation can return exceptions when something goes wrong, however the traceback from the exception was not logged properly.

In addition, add a note about what a common error type could mean on the GRiD end to clarify things for users.