### PR TITLE
Raise RuntimeError When No Token Provided

### DIFF
--- a/src/doppkit/__init__.py
+++ b/src/doppkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 from . import cache
 from . import grid

--- a/src/doppkit/app.py
+++ b/src/doppkit/app.py
@@ -49,6 +49,11 @@ class Application:
             Filter out AOI PKs below this value.
         """
         self.token = token if token is not None else os.getenv("GRID_ACCESS_TOKEN", "")
+        if not self.token:
+            raise RuntimeError(
+                "No GRiD Token Provided either by argument or GRID_ACCESS_TOKEN "
+                "environment variable."
+            )
         # need to assign the attribute
         self._url = ""
         self.url = url

--- a/src/doppkit/grid.py
+++ b/src/doppkit/grid.py
@@ -356,7 +356,12 @@ class Grid:
             return []
         except AttributeError as e:
             if isinstance(export_files[0], Exception):
-                logger.error(f"Doppkit Cache Function Returned the following exception: {export_files[0]}")
+                logger.error("Doppkit Cache Function Returned the following exception:")
+                logger.error(export_files[0], exc_info=export_files[0])
+                logger.info(
+                    "If the above is a httpx.ReadError, likely a timeout on the GRiD "
+                    "end has interrupted the download."
+                )
                 raise export_files[0] from e
             elif isinstance(export_files[0], httpx.Response):            
                 await export_files[0].aread()


### PR DESCRIPTION
When no token is provided, GRiD will return an error which can be hard to decode downstream.  Since we know earlier on in the process if a token is not provided, we can raise an error then.

Also add more logging information when GRiD does return an error.